### PR TITLE
Fix Nil handling in extract and complicated case

### DIFF
--- a/input/src/main/scala/test/EmptyCollectionsUnified.scala
+++ b/input/src/main/scala/test/EmptyCollectionsUnified.scala
@@ -48,6 +48,30 @@ object EmptyCollectionsUnified {
       case _ => 2
     }
 
+    // should not rewrite Nil when used within nested unapply
+    val la = (a, List(a)) match {
+      case (_, List(Nil)) => 1
+      case _ => 2
+    }
+
+    // should rewrite List() to Nil when used within nested unapply
+    val ld = (a, List(a)) match {
+      case (_, List(List())) => 1
+      case _ => 2
+    }
+
+    // should not rewrite Nil on alternative case match
+    val lb = a match {
+      case Nil|Nil => 1
+      case _ => 2
+    }
+
+    // should rewrite List() to Nil on alternative case match
+    val lc = a match {
+      case List()|List() => 1
+      case _ => 2
+    }
+
     // should rewrite to Nil when used within unapply
     val m = (a, a) match {
       case (List(), List()) => 1
@@ -56,6 +80,24 @@ object EmptyCollectionsUnified {
 
     // non-empty list construction shouldn't be rewritten
     val n = List(1, 2, 3)
+
+    // Nil in application not being :: should be replace by List.empty
+    val o = List(Nil)
+
+    // Nil in infix application not being :: should be replace by List.empty
+    val q = List.empty ++ Nil
+
+    // List() should be replace to Nil when deconstructing type
+    val List(List(), r) = List(List(), List(1, 2))
+
+    // Nil should not be replaced to List.empty when deconstructing type (nested)
+    val List(List(List()), u) = List(List(List()), List(1, 2))
+
+    // Nil should not be replaced when deconstructing type
+    val List(Nil, v) = List(List(), List(1, 2))
+
+    // Nil should not be replaced when deconstructing type (nested)
+    val List(List(Nil), w) = List(List(List()), List(1, 2))
   }
 
   object set {

--- a/input/src/main/scala/test/EmptyCollectionsUnified.scala
+++ b/input/src/main/scala/test/EmptyCollectionsUnified.scala
@@ -62,13 +62,13 @@ object EmptyCollectionsUnified {
 
     // should not rewrite Nil on alternative case match
     val lb = a match {
-      case Nil|Nil => 1
+      case Nil | Nil => 1
       case _ => 2
     }
 
     // should rewrite List() to Nil on alternative case match
     val lc = a match {
-      case List()|List() => 1
+      case List() | List() => 1
       case _ => 2
     }
 

--- a/output/src/main/scala/test/EmptyCollectionsUnified.scala
+++ b/output/src/main/scala/test/EmptyCollectionsUnified.scala
@@ -59,13 +59,13 @@ object EmptyCollectionsUnified {
 
     // should not rewrite Nil on alternative case match
     val lb = a match {
-      case Nil|Nil => 1
+      case Nil | Nil => 1
       case _ => 2
     }
 
     // should rewrite List() to Nil on alternative case match
     val lc = a match {
-      case Nil|Nil => 1
+      case Nil | Nil => 1
       case _ => 2
     }
 

--- a/output/src/main/scala/test/EmptyCollectionsUnified.scala
+++ b/output/src/main/scala/test/EmptyCollectionsUnified.scala
@@ -45,6 +45,30 @@ object EmptyCollectionsUnified {
       case _ => 2
     }
 
+    // should not rewrite Nil when used within nested unapply
+    val la = (a, List(a)) match {
+      case (_, List(Nil)) => 1
+      case _ => 2
+    }
+
+    // should rewrite List() to Nil when used within nested unapply
+    val ld = (a, List(a)) match {
+      case (_, List(Nil)) => 1
+      case _ => 2
+    }
+
+    // should not rewrite Nil on alternative case match
+    val lb = a match {
+      case Nil|Nil => 1
+      case _ => 2
+    }
+
+    // should rewrite List() to Nil on alternative case match
+    val lc = a match {
+      case Nil|Nil => 1
+      case _ => 2
+    }
+
     // should rewrite to Nil when used within unapply
     val m = (a, a) match {
       case (Nil, Nil) => 1
@@ -53,6 +77,24 @@ object EmptyCollectionsUnified {
 
     // non-empty list construction shouldn't be rewritten
     val n = List(1, 2, 3)
+
+    // Nil in application not being :: should be replace by List.empty
+    val o = List(List.empty)
+
+    // Nil in infix application not being :: should be replace by List.empty
+    val q = List.empty ++ List.empty
+
+    // List() should be replace to Nil when deconstructing type
+    val List(Nil, r) = List(List.empty, List(1, 2))
+
+    // Nil should not be replaced to List.empty when deconstructing type (nested)
+    val List(List(Nil), u) = List(List(List.empty), List(1, 2))
+
+    // Nil should not be replaced when deconstructing type
+    val List(Nil, v) = List(List.empty, List(1, 2))
+
+    // Nil should not be replaced when deconstructing type (nested)
+    val List(List(Nil), w) = List(List(List.empty), List(1, 2))
   }
 
   object set {


### PR DESCRIPTION
Before `val a::Nil = List(1)` was rewritten to
`val List.empty::Nil = List(1)`

`case Nil|Nil =>` was rewritten to
`case List.empty|List.empty`

and
`case (a, List(Nil)) =>` was rewritten to
`case (a, List(List.empty))`