### PR TITLE
Use `.atomic`

### DIFF
--- a/input/src/main/scala/test/EmptyCollectionsUnified.scala
+++ b/input/src/main/scala/test/EmptyCollectionsUnified.scala
@@ -98,6 +98,51 @@ object EmptyCollectionsUnified {
 
     // Nil should not be replaced when deconstructing type (nested)
     val List(List(Nil), w) = List(List(List()), List(1, 2))
+
+    // should respect suppresions
+    // scalafix:off
+    object suppresions {
+      val a = List[Int]()
+      val b: List[Int] = List()
+      val c = List.empty[Int]
+      val d: List[Int] = List.empty
+
+      val e = a match {
+        case List() => 1
+        case _ => 2
+      }
+
+      val h: List[Int] = Nil
+
+      val ld = (a, List(a)) match {
+        case (_, List(List())) => 1
+        case _ => 2
+      }
+
+      val lb = a match {
+        case Nil | Nil => 1
+        case _ => 2
+      }
+
+      val lc = a match {
+        case List() | List() => 1
+        case _ => 2
+      }
+
+      val m = (a, a) match {
+        case (List(), List()) => 1
+        case _ => 2
+      }
+
+      val o = List(Nil)
+
+      val q = List.empty ++ Nil
+
+      val List(List(), r) = List(List(), List(1, 2))
+
+      val List(List(List()), u) = List(List(List()), List(1, 2))
+    }
+    // scalafix:on
   }
 
   object set {
@@ -105,6 +150,15 @@ object EmptyCollectionsUnified {
     val b: Set[Int] = Set()
     val c = Set.empty[Int]
     val d: Set[Int] = Set.empty
+
+    // scalafix:off
+    object suppressions {
+      val a = List[Int]()
+      val b: List[Int] = List()
+      val c = List.empty[Int]
+      val d: List[Int] = List.empty
+    }
+    // scalafix:on
   }
 
   object map {
@@ -112,5 +166,14 @@ object EmptyCollectionsUnified {
     val b: Map[Int, Int] = Map()
     val c = Map.empty[Int, Int]
     val d: Map[Int, Int] = Map.empty
+
+    // scalafix:off
+    object suppressions {
+      val a = Map[Int, Int]()
+      val b: Map[Int, Int] = Map()
+      val c = Map.empty[Int, Int]
+      val d: Map[Int, Int] = Map.empty
+    }
+    // scalafix:on
   }
 }

--- a/output/src/main/scala/test/EmptyCollectionsUnified.scala
+++ b/output/src/main/scala/test/EmptyCollectionsUnified.scala
@@ -95,6 +95,51 @@ object EmptyCollectionsUnified {
 
     // Nil should not be replaced when deconstructing type (nested)
     val List(List(Nil), w) = List(List(List.empty), List(1, 2))
+
+    // should respect suppresions
+    // scalafix:off
+    object suppresions {
+      val a = List[Int]()
+      val b: List[Int] = List()
+      val c = List.empty[Int]
+      val d: List[Int] = List.empty
+
+      val e = a match {
+        case List() => 1
+        case _ => 2
+      }
+
+      val h: List[Int] = Nil
+
+      val ld = (a, List(a)) match {
+        case (_, List(List())) => 1
+        case _ => 2
+      }
+
+      val lb = a match {
+        case Nil | Nil => 1
+        case _ => 2
+      }
+
+      val lc = a match {
+        case List() | List() => 1
+        case _ => 2
+      }
+
+      val m = (a, a) match {
+        case (List(), List()) => 1
+        case _ => 2
+      }
+
+      val o = List(Nil)
+
+      val q = List.empty ++ Nil
+
+      val List(List(), r) = List(List(), List(1, 2))
+
+      val List(List(List()), u) = List(List(List()), List(1, 2))
+    }
+    // scalafix:on
   }
 
   object set {
@@ -102,6 +147,15 @@ object EmptyCollectionsUnified {
     val b: Set[Int] = Set.empty
     val c = Set.empty[Int]
     val d: Set[Int] = Set.empty
+
+    // scalafix:off
+    object suppressions {
+      val a = List[Int]()
+      val b: List[Int] = List()
+      val c = List.empty[Int]
+      val d: List[Int] = List.empty
+    }
+    // scalafix:on
   }
 
   object map {
@@ -109,5 +163,14 @@ object EmptyCollectionsUnified {
     val b: Map[Int, Int] = Map.empty
     val c = Map.empty[Int, Int]
     val d: Map[Int, Int] = Map.empty
+
+    // scalafix:off
+    object suppressions {
+      val a = Map[Int, Int]()
+      val b: Map[Int, Int] = Map()
+      val c = Map.empty[Int, Int]
+      val d: Map[Int, Int] = Map.empty
+    }
+    // scalafix:on
   }
 }

--- a/rules/src/main/scala/fix/EmptyCollectionsUnified.scala
+++ b/rules/src/main/scala/fix/EmptyCollectionsUnified.scala
@@ -7,15 +7,15 @@ import scala.meta._
 class EmptyCollectionsUnified extends SemanticRule("EmptyCollectionsUnified") {
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
-      case t @ q"List[$e]()" => Patch.replaceTree(t, s"List.empty[$e]")
+      case t @ q"List[$e]()" => Patch.replaceTree(t, s"List.empty[$e]").atomic
       case t @ Term.Name("List") =>
         t.parent match {
           // val b: List[Int] = List()
           case Some(p @ Term.Apply(_, Nil)) =>
-            Patch.replaceTree(p, "List.empty")
+            Patch.replaceTree(p, "List.empty").atomic
           //  case (List(), List()) =>
           //  case List() =>
-          case Some(p @ p"List()") => Patch.replaceTree(p, "Nil")
+          case Some(p @ p"List()") => Patch.replaceTree(p, "Nil").atomic
           case _ => Patch.empty
         }
       case t @ q"Nil" =>
@@ -26,12 +26,12 @@ class EmptyCollectionsUnified extends SemanticRule("EmptyCollectionsUnified") {
           case Some(Term.ApplyInfix((_, Term.Name("::"), _, _))) => Patch.empty
           // case Nil =>
           case Some(t) if treeInsidePatternMatching(t) => Patch.empty
-          case _ => Patch.replaceTree(t, s"List.empty")
+          case _ => Patch.replaceTree(t, s"List.empty").atomic
         }
-      case t @ q"Set()" => Patch.replaceTree(t, "Set.empty")
-      case t @ q"Set[$e]()" => Patch.replaceTree(t, s"Set.empty[$e]")
-      case t @ q"Map()" => Patch.replaceTree(t, "Map.empty")
-      case t @ q"Map[$k, $v]()" => Patch.replaceTree(t, s"Map.empty[$k, $v]")
+      case t @ q"Set()" => Patch.replaceTree(t, "Set.empty").atomic
+      case t @ q"Set[$e]()" => Patch.replaceTree(t, s"Set.empty[$e]").atomic
+      case t @ q"Map()" => Patch.replaceTree(t, "Map.empty").atomic
+      case t @ q"Map[$k, $v]()" => Patch.replaceTree(t, s"Map.empty[$k, $v]").atomic
       case _ => Patch.empty
     }.asPatch
   }


### PR DESCRIPTION
Hi!  This PR makes the `EmptyCollectionsUnified` rule mark its patches as atomic using [`.atomic`](https://scalacenter.github.io/scalafix/docs/developers/patch.html#atomic) (where applicable) which makes the rule respect supressions, and is also used by the scalafix api to group patches.

Thanks!